### PR TITLE
Update requestPresenter definition to accept dictionary

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -49,20 +49,26 @@ For example, consider an application that has rendered all ink strokes up to the
 <pre class="idl lang-idl">
 interface Ink {
     Promise&lt;InkPresenter&gt; requestPresenter(
-        DOMString type,
-        optional Element? presentationArea = null);
+        optional InkPresenterParam? param = null);
 };
 </pre>
 
 <dl dfn-type="method" dfn-for="Ink">
-    : <dfn>requestPresenter(type, presentationArea)</dfn>
+    : <dfn>requestPresenter(param)</dfn>
     :: This method returns an instance of an InkPresenter object within a Promise that can be used to render ink strokes in-between {{PointerEvent}} dispatches. Each time this method is called, a new InkPresenter instance must be created.
 </dl>
 
-<pre class="argumentdef" for="Ink/requestPresenter()">
-type: The type of the presenter
-presentationArea: An optional {{Element}} that confines the rendering of ink trails to the area bound by the element.
+## {{InkPresenterParam}} dictionary ## {#ink-presenter-param}
+<pre class="idl lang-idl">
+dictionary InkPresenterParam {
+    Element? presentationArea = null;
+};
 </pre>
+
+<dl dfn-type="dict-member" dfn-for="InkPresenterParam">
+    : <dfn>presentationArea</dfn>
+    :: An optional {{Element}} that confines the rendering of ink trails to the area bound by the element. presentationArea must either be null or be in the same document as the Ink interface, otherwise throw an error and abort.
+</dl>
 
 ## {{InkPresenter}} interface ## {#ink-presenter}
 <pre class="idl lang-idl">
@@ -84,7 +90,7 @@ interface InkPresenter {
 
 <dl dfn-type="method" dfn-for="InkPresenter">
     : <dfn>updateInkTrailStartPoint(event, style)</dfn>
-    :: This method indicates to the presenter which {{PointerEvent}} was used as the last rendering point for the current frame. This must be a trusted event that is in the same document as the {{InkPresenter}}.
+    :: This method indicates to the presenter which {{PointerEvent}} was used as the last rendering point for the current frame. This must be a trusted event that is in the same document as the {{InkPresenter}}. The produced delegated ink trail must be rendered for the duration of the next animation frame and then removed.
 </dl>
 
 ## {{InkTrailStyle}} dictionary ## {#ink-trail-style}
@@ -97,9 +103,9 @@ dictionary InkTrailStyle {
 
 <dl dfn-type="dict-member" dfn-for="InkTrailStyle">
     : <dfn>color</dfn>
-    :: This specifies a CSS color code for the presenter to use when rendering the ink trail.
+    :: This specifies a CSS color code for the presenter to use when rendering the ink trail. It must be a valid CSS color, otherwise throw an error and abort.
     : <dfn>diameter</dfn>
-    :: This specifies the diameter of that the presenter should use when displaying the ink trail.
+    :: This specifies the diameter of that the presenter should use when displaying the ink trail. It must be greater than 0, otherwise throw an error and abort.
 </dl>
 
 ## {{Ink}} Navigator interface extension ## {#navigator-interface-extensions}
@@ -129,7 +135,7 @@ function renderInkStroke(x, y, canvas) {
 
 try {
     let canvas = document.querySelector("#canvas");
-    let presenter = await navigator.ink.requestPresenter('delegated-ink-trail', canvas);
+    let presenter = await navigator.ink.requestPresenter({presentationArea: canvas});
 
     // With 'pointerraw' events and JavaScript prediction, we can reduce latency by 16ms, so
     // fallback if InkPresenter is not capable of providing a benefit.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <title>Ink API</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 3d6a6fcbb, updated Wed Jun 16 16:19:39 2021 -0700" name="generator">
+  <meta content="Bikeshed version bb6b91100, updated Mon Jul 12 16:52:37 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/2021/ink-api" rel="canonical">
 <style>/* style-autolinks */
 
@@ -566,7 +566,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Ink API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-07-07">7 July 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-07-13">13 July 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -608,9 +608,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <ol class="toc">
       <li><a href="#ink-api-introduction"><span class="secno">3.1</span> <span class="content">Introduction</span></a>
       <li><a href="#ink-interface"><span class="secno">3.2</span> <span class="content"><code class="idl"><span>Ink</span></code> interface</span></a>
-      <li><a href="#ink-presenter"><span class="secno">3.3</span> <span class="content"><code class="idl"><span>InkPresenter</span></code> interface</span></a>
-      <li><a href="#ink-trail-style"><span class="secno">3.4</span> <span class="content"><code class="idl"><span>InkTrailStyle</span></code> dictionary</span></a>
-      <li><a href="#navigator-interface-extensions"><span class="secno">3.5</span> <span class="content"><code class="idl"><span>Ink</span></code> Navigator interface extension</span></a>
+      <li><a href="#ink-presenter-param"><span class="secno">3.3</span> <span class="content"><code class="idl"><span>InkPresenterParam</span></code> dictionary</span></a>
+      <li><a href="#ink-presenter"><span class="secno">3.4</span> <span class="content"><code class="idl"><span>InkPresenter</span></code> interface</span></a>
+      <li><a href="#ink-trail-style"><span class="secno">3.5</span> <span class="content"><code class="idl"><span>InkTrailStyle</span></code> dictionary</span></a>
+      <li><a href="#navigator-interface-extensions"><span class="secno">3.6</span> <span class="content"><code class="idl"><span>Ink</span></code> Navigator interface extension</span></a>
      </ol>
     <li><a href="#usage-examples"><span class="secno">4</span> <span class="content">Usage Examples</span></a>
     <li>
@@ -651,49 +652,35 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <h3 class="heading settled" data-level="3.2" id="ink-interface"><span class="secno">3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#ink" id="ref-for-ink">Ink</a></code> interface</span><a class="self-link" href="#ink-interface"></a></h3>
 <pre class="idl lang-idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="ink"><code><c- g>Ink</c-></code></dfn> {
     <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#inkpresenter" id="ref-for-inkpresenter①"><c- n>InkPresenter</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-ink-requestpresenter" id="ref-for-dom-ink-requestpresenter"><c- g>requestPresenter</c-></a>(
-        <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Ink/requestPresenter(type, presentationArea), Ink/requestPresenter(type)" data-dfn-type="argument" data-export id="dom-ink-requestpresenter-type-presentationarea-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-ink-requestpresenter-type-presentationarea-type"></a></dfn>,
-        <c- b>optional</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element"><c- n>Element</c-></a>? <dfn class="idl-code" data-dfn-for="Ink/requestPresenter(type, presentationArea), Ink/requestPresenter(type)" data-dfn-type="argument" data-export id="dom-ink-requestpresenter-type-presentationarea-presentationarea"><code><c- g>presentationArea</c-></code><a class="self-link" href="#dom-ink-requestpresenter-type-presentationarea-presentationarea"></a></dfn> = <c- b>null</c->);
+        <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-inkpresenterparam" id="ref-for-dictdef-inkpresenterparam"><c- n>InkPresenterParam</c-></a>? <dfn class="idl-code" data-dfn-for="Ink/requestPresenter(param), Ink/requestPresenter()" data-dfn-type="argument" data-export id="dom-ink-requestpresenter-param-param"><code><c- g>param</c-></code><a class="self-link" href="#dom-ink-requestpresenter-param-param"></a></dfn> = <c- b>null</c->);
 };
 </pre>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="Ink" data-dfn-type="method" data-export data-lt="requestPresenter(type, presentationArea)|requestPresenter(type)" id="dom-ink-requestpresenter"><code>requestPresenter(type, presentationArea)</code></dfn>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="Ink" data-dfn-type="method" data-export data-lt="requestPresenter(param)|requestPresenter()" id="dom-ink-requestpresenter"><code>requestPresenter(param)</code></dfn>
     <dd data-md>
      <p>This method returns an instance of an InkPresenter object within a Promise that can be used to render ink strokes in-between <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent②">PointerEvent</a></code> dispatches. Each time this method is called, a new InkPresenter instance must be created.</p>
    </dl>
-   <table class="argumentdef data">
-    <caption>Arguments for the <a data-link-type="idl" href="#dom-ink-requestpresenter" id="ref-for-dom-ink-requestpresenter①">Ink.requestPresenter()</a> method.</caption>
-    <thead>
-     <tr>
-      <th>Parameter 
-      <th>Type 
-      <th>Nullable 
-      <th>Optional 
-      <th>Description 
-    <tbody>
-     <tr>
-      <td><dfn class="idl-code" data-dfn-for="Ink/requestPresenter()" data-dfn-type="argument" data-export id="dom-ink-requestpresenter-type"><code>type</code><a class="self-link" href="#dom-ink-requestpresenter-type"></a></dfn> 
-      <td> DOMString 
-      <td> <span class="no">✘</span>
-      <td> <span class="no">✘</span>
-      <td>The type of the presenter 
-     <tr>
-      <td><dfn class="dfn-paneled idl-code" data-dfn-for="Ink/requestPresenter()" data-dfn-type="argument" data-export id="dom-ink-requestpresenter-presentationarea"><code>presentationArea</code></dfn> 
-      <td> Element? 
-      <td> <span class="yes">✔</span>
-      <td> <span class="yes">✔</span>
-      <td>An optional <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code> that confines the rendering of ink trails to the area bound by the element.
-   </table>
-   <h3 class="heading settled" data-level="3.3" id="ink-presenter"><span class="secno">3.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#inkpresenter" id="ref-for-inkpresenter②">InkPresenter</a></code> interface</span><a class="self-link" href="#ink-presenter"></a></h3>
+   <h3 class="heading settled" data-level="3.3" id="ink-presenter-param"><span class="secno">3.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dictdef-inkpresenterparam" id="ref-for-dictdef-inkpresenterparam①">InkPresenterParam</a></code> dictionary</span><a class="self-link" href="#ink-presenter-param"></a></h3>
+<pre class="idl lang-idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-inkpresenterparam"><code><c- g>InkPresenterParam</c-></code></dfn> {
+    <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element"><c- n>Element</c-></a>? <a class="idl-code" data-default="null" data-link-type="dict-member" data-type="Element? " href="#dom-inkpresenterparam-presentationarea" id="ref-for-dom-inkpresenterparam-presentationarea"><c- g>presentationArea</c-></a> = <c- b>null</c->;
+};
+</pre>
+   <dl>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkPresenterParam" data-dfn-type="dict-member" data-export id="dom-inkpresenterparam-presentationarea"><code>presentationArea</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a>, nullable, defaulting to <code>null</code></span>
+    <dd data-md>
+     <p>An optional <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> that confines the rendering of ink trails to the area bound by the element. presentationArea must either be null or be in the same document as the Ink interface, otherwise throw an error and abort.</p>
+   </dl>
+   <h3 class="heading settled" data-level="3.4" id="ink-presenter"><span class="secno">3.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#inkpresenter" id="ref-for-inkpresenter②">InkPresenter</a></code> interface</span><a class="self-link" href="#ink-presenter"></a></h3>
 <pre class="idl lang-idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="inkpresenter"><code><c- g>InkPresenter</c-></code></dfn> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②"><c- n>Element</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="Element?" href="#dom-inkpresenter-presentationarea" id="ref-for-dom-inkpresenter-presentationarea"><c- g>presentationArea</c-></a>;
+    <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③"><c- n>Element</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="Element?" href="#dom-inkpresenter-presentationarea" id="ref-for-dom-inkpresenter-presentationarea"><c- g>presentationArea</c-></a>;
     <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-inkpresenter-expectedimprovement" id="ref-for-dom-inkpresenter-expectedimprovement"><c- g>expectedImprovement</c-></a>;
 
     <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-inkpresenter-updateinktrailstartpoint" id="ref-for-dom-inkpresenter-updateinktrailstartpoint"><c- g>updateInkTrailStartPoint</c-></a>(<a data-link-type="idl-name" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent③"><c- n>PointerEvent</c-></a> <dfn class="idl-code" data-dfn-for="InkPresenter/updateInkTrailStartPoint(event, style)" data-dfn-type="argument" data-export id="dom-inkpresenter-updateinktrailstartpoint-event-style-event"><code><c- g>event</c-></code><a class="self-link" href="#dom-inkpresenter-updateinktrailstartpoint-event-style-event"></a></dfn>, <a data-link-type="idl-name" href="#dictdef-inktrailstyle" id="ref-for-dictdef-inktrailstyle"><c- n>InkTrailStyle</c-></a> <dfn class="idl-code" data-dfn-for="InkPresenter/updateInkTrailStartPoint(event, style)" data-dfn-type="argument" data-export id="dom-inkpresenter-updateinktrailstartpoint-event-style-style"><code><c- g>style</c-></code><a class="self-link" href="#dom-inkpresenter-updateinktrailstartpoint-event-style-style"></a></dfn>);
 };
 </pre>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkPresenter" data-dfn-type="attribute" data-export id="dom-inkpresenter-presentationarea"><code>presentationArea</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a>, readonly, nullable</span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkPresenter" data-dfn-type="attribute" data-export id="dom-inkpresenter-presentationarea"><code>presentationArea</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a>, readonly, nullable</span>
     <dd data-md>
      <p>A reference to the DOM element to which the presenter is scoped to prevent ink presentation outside of the provided area. This area is always the client coordinates for the element’s border box, so moving the element or scrolling the element requires no recalculation on the author’s part. If this is not provided, the default is to use the containing viewport. This element must be in the same document that the InkPresenter is associated with and the same document that is receiving the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent④">PointerEvent</a></code>s, otherwise an error is thrown. If presentationArea is ever removed from the document, the next updateInkTrailStartPoint must throw an error and abort.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkPresenter" data-dfn-type="attribute" data-export id="dom-inkpresenter-expectedimprovement"><code>expectedImprovement</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①">unsigned long</a>, readonly</span>
@@ -703,23 +690,23 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkPresenter" data-dfn-type="method" data-export id="dom-inkpresenter-updateinktrailstartpoint"><code>updateInkTrailStartPoint(event, style)</code></dfn>
     <dd data-md>
-     <p>This method indicates to the presenter which <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent⑤">PointerEvent</a></code> was used as the last rendering point for the current frame. This must be a trusted event that is in the same document as the <code class="idl"><a data-link-type="idl" href="#inkpresenter" id="ref-for-inkpresenter③">InkPresenter</a></code>.</p>
+     <p>This method indicates to the presenter which <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent⑤">PointerEvent</a></code> was used as the last rendering point for the current frame. This must be a trusted event that is in the same document as the <code class="idl"><a data-link-type="idl" href="#inkpresenter" id="ref-for-inkpresenter③">InkPresenter</a></code>. The produced delegated ink trail must be rendered for the duration of the next animation frame and then removed.</p>
    </dl>
-   <h3 class="heading settled" data-level="3.4" id="ink-trail-style"><span class="secno">3.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dictdef-inktrailstyle" id="ref-for-dictdef-inktrailstyle①">InkTrailStyle</a></code> dictionary</span><a class="self-link" href="#ink-trail-style"></a></h3>
+   <h3 class="heading settled" data-level="3.5" id="ink-trail-style"><span class="secno">3.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dictdef-inktrailstyle" id="ref-for-dictdef-inktrailstyle①">InkTrailStyle</a></code> dictionary</span><a class="self-link" href="#ink-trail-style"></a></h3>
 <pre class="idl lang-idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-inktrailstyle"><code><c- g>InkTrailStyle</c-></code></dfn> {
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMString " href="#dom-inktrailstyle-color" id="ref-for-dom-inktrailstyle-color"><c- g>color</c-></a>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMString " href="#dom-inktrailstyle-color" id="ref-for-dom-inktrailstyle-color"><c- g>color</c-></a>;
     <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double" id="ref-for-idl-unrestricted-double"><c- b>unrestricted</c-> <c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unrestricted double " href="#dom-inktrailstyle-diameter" id="ref-for-dom-inktrailstyle-diameter"><c- g>diameter</c-></a>;
 };
 </pre>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkTrailStyle" data-dfn-type="dict-member" data-export id="dom-inktrailstyle-color"><code>color</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②">DOMString</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkTrailStyle" data-dfn-type="dict-member" data-export id="dom-inktrailstyle-color"><code>color</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①">DOMString</a></span>
     <dd data-md>
-     <p>This specifies a CSS color code for the presenter to use when rendering the ink trail.</p>
+     <p>This specifies a CSS color code for the presenter to use when rendering the ink trail. It must be a valid CSS color, otherwise throw an error and abort.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkTrailStyle" data-dfn-type="dict-member" data-export id="dom-inktrailstyle-diameter"><code>diameter</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unrestricted-double" id="ref-for-idl-unrestricted-double①">unrestricted double</a></span>
     <dd data-md>
-     <p>This specifies the diameter of that the presenter should use when displaying the ink trail.</p>
+     <p>This specifies the diameter of that the presenter should use when displaying the ink trail. It must be greater than 0, otherwise throw an error and abort.</p>
    </dl>
-   <h3 class="heading settled" data-level="3.5" id="navigator-interface-extensions"><span class="secno">3.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#ink" id="ref-for-ink①">Ink</a></code> Navigator interface extension</span><a class="self-link" href="#navigator-interface-extensions"></a></h3>
+   <h3 class="heading settled" data-level="3.6" id="navigator-interface-extensions"><span class="secno">3.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#ink" id="ref-for-ink①">Ink</a></code> Navigator interface extension</span><a class="self-link" href="#navigator-interface-extensions"></a></h3>
     This partial interface defines an extension to the Navigator interface 
 <pre class="idl lang-idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/system-state.html#navigator" id="ref-for-navigator"><c- g>Navigator</c-></a> {
@@ -729,7 +716,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export id="dom-navigator-ink"><code>ink</code></dfn>, <span> of type <a data-link-type="idl-name" href="#ink" id="ref-for-ink③">Ink</a>, readonly</span>
     <dd data-md>
-     <p>An instance of <code class="idl"><a data-link-type="idl" href="#ink" id="ref-for-ink④">Ink</a></code> for the current document. It must be associated with the same document that will contain the <code class="idl"><a data-link-type="idl" href="#dom-ink-requestpresenter-presentationarea" id="ref-for-dom-ink-requestpresenter-presentationarea">presentationArea</a></code> and that will receive the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent⑥">PointerEvent</a></code>s to draw.</p>
+     <p>An instance of <code class="idl"><a data-link-type="idl" href="#ink" id="ref-for-ink④">Ink</a></code> for the current document. It must be associated with the same document that will contain the <code class="idl"><a data-link-type="idl" href="#dom-inkpresenterparam-presentationarea" id="ref-for-dom-inkpresenterparam-presentationarea①">presentationArea</a></code> and that will receive the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent⑥">PointerEvent</a></code>s to draw.</p>
    </dl>
    <h2 class="heading settled" data-level="4" id="usage-examples"><span class="secno">4. </span><span class="content">Usage Examples</span><a class="self-link" href="#usage-examples"></a></h2>
 <pre class="javascript lang-javascript highlight"><c- a>const</c-> MIN_EXPECTED_IMPROVEMENT <c- o>=</c-> <c- mf>16</c-><c- p>;</c->
@@ -740,7 +727,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 
 <c- k>try</c-> <c- p>{</c->
     <c- a>let</c-> canvas <c- o>=</c-> document<c- p>.</c->querySelector<c- p>(</c-><c- u>"#canvas"</c-><c- p>);</c->
-    <c- a>let</c-> presenter <c- o>=</c-> <c- k>await</c-> navigator<c- p>.</c->ink<c- p>.</c->requestPresenter<c- p>(</c-><c- t>'delegated-ink-trail'</c-><c- p>,</c-> canvas<c- p>);</c->
+    <c- a>let</c-> presenter <c- o>=</c-> <c- k>await</c-> navigator<c- p>.</c->ink<c- p>.</c->requestPresenter<c- p>({</c->presentationArea<c- o>:</c-> canvas<c- p>});</c->
 
     <c- c1>// With 'pointerraw' events and JavaScript prediction, we can reduce latency by 16ms, so</c->
     <c- c1>// fallback if InkPresenter is not capable of providing a benefit.</c->
@@ -813,29 +800,35 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-inktrailstyle-color">color</a><span>, in §3.4</span>
-   <li><a href="#dom-inktrailstyle-diameter">diameter</a><span>, in §3.4</span>
-   <li><a href="#dom-inkpresenter-expectedimprovement">expectedImprovement</a><span>, in §3.3</span>
+   <li><a href="#dom-inktrailstyle-color">color</a><span>, in §3.5</span>
+   <li><a href="#dom-inktrailstyle-diameter">diameter</a><span>, in §3.5</span>
+   <li><a href="#dom-inkpresenter-expectedimprovement">expectedImprovement</a><span>, in §3.4</span>
    <li><a href="#ink">Ink</a><span>, in §3.2</span>
-   <li><a href="#dom-navigator-ink">ink</a><span>, in §3.5</span>
-   <li><a href="#inkpresenter">InkPresenter</a><span>, in §3.3</span>
-   <li><a href="#dictdef-inktrailstyle">InkTrailStyle</a><span>, in §3.4</span>
-   <li><a href="#dom-inkpresenter-presentationarea">presentationArea</a><span>, in §3.3</span>
-   <li><a href="#dom-ink-requestpresenter">requestPresenter(type)</a><span>, in §3.2</span>
-   <li><a href="#dom-ink-requestpresenter">requestPresenter(type, presentationArea)</a><span>, in §3.2</span>
-   <li><a href="#dom-inkpresenter-updateinktrailstartpoint">updateInkTrailStartPoint(event, style)</a><span>, in §3.3</span>
+   <li><a href="#dom-navigator-ink">ink</a><span>, in §3.6</span>
+   <li><a href="#inkpresenter">InkPresenter</a><span>, in §3.4</span>
+   <li><a href="#dictdef-inkpresenterparam">InkPresenterParam</a><span>, in §3.3</span>
+   <li><a href="#dictdef-inktrailstyle">InkTrailStyle</a><span>, in §3.5</span>
+   <li>
+    presentationArea
+    <ul>
+     <li><a href="#dom-inkpresenter-presentationarea">attribute for InkPresenter</a><span>, in §3.4</span>
+     <li><a href="#dom-inkpresenterparam-presentationarea">dict-member for InkPresenterParam</a><span>, in §3.3</span>
+    </ul>
+   <li><a href="#dom-ink-requestpresenter">requestPresenter()</a><span>, in §3.2</span>
+   <li><a href="#dom-ink-requestpresenter">requestPresenter(param)</a><span>, in §3.2</span>
+   <li><a href="#dom-inkpresenter-updateinktrailstartpoint">updateInkTrailStartPoint(event, style)</a><span>, in §3.4</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-element">
    <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-element">3.2. Ink interface</a> <a href="#ref-for-element①">(2)</a>
-    <li><a href="#ref-for-element②">3.3. InkPresenter interface</a> <a href="#ref-for-element③">(2)</a>
+    <li><a href="#ref-for-element">3.3. InkPresenterParam dictionary</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a>
+    <li><a href="#ref-for-element③">3.4. InkPresenter interface</a> <a href="#ref-for-element④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-navigator">
    <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-navigator">3.5. Ink Navigator interface extension</a>
+    <li><a href="#ref-for-navigator">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-context-2d-canvas">
@@ -850,8 +843,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-dom-pointerevent">1. Introduction</a>
     <li><a href="#ref-for-dom-pointerevent①">3.1. Introduction</a>
     <li><a href="#ref-for-dom-pointerevent②">3.2. Ink interface</a>
-    <li><a href="#ref-for-dom-pointerevent③">3.3. InkPresenter interface</a> <a href="#ref-for-dom-pointerevent④">(2)</a> <a href="#ref-for-dom-pointerevent⑤">(3)</a>
-    <li><a href="#ref-for-dom-pointerevent⑥">3.5. Ink Navigator interface extension</a>
+    <li><a href="#ref-for-dom-pointerevent③">3.4. InkPresenter interface</a> <a href="#ref-for-dom-pointerevent④">(2)</a> <a href="#ref-for-dom-pointerevent⑤">(3)</a>
+    <li><a href="#ref-for-dom-pointerevent⑥">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-pointerevent-getpredictedevents">
@@ -863,15 +856,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
    <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-DOMString">3.2. Ink interface</a>
-    <li><a href="#ref-for-idl-DOMString①">3.4. InkTrailStyle dictionary</a> <a href="#ref-for-idl-DOMString②">(2)</a>
+    <li><a href="#ref-for-idl-DOMString">3.5. InkTrailStyle dictionary</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
    <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Exposed">3.3. InkPresenter interface</a>
-    <li><a href="#ref-for-Exposed①">3.5. Ink Navigator interface extension</a>
+    <li><a href="#ref-for-Exposed">3.4. InkPresenter interface</a>
+    <li><a href="#ref-for-Exposed①">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-promise">
@@ -883,25 +875,25 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="term-for-SameObject">
    <a href="https://heycam.github.io/webidl/#SameObject">https://heycam.github.io/webidl/#SameObject</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-SameObject">3.5. Ink Navigator interface extension</a>
+    <li><a href="#ref-for-SameObject">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
    <a href="https://heycam.github.io/webidl/#idl-undefined">https://heycam.github.io/webidl/#idl-undefined</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-undefined">3.3. InkPresenter interface</a>
+    <li><a href="#ref-for-idl-undefined">3.4. InkPresenter interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
    <a href="https://heycam.github.io/webidl/#idl-unrestricted-double">https://heycam.github.io/webidl/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-unrestricted-double">3.4. InkTrailStyle dictionary</a> <a href="#ref-for-idl-unrestricted-double①">(2)</a>
+    <li><a href="#ref-for-idl-unrestricted-double">3.5. InkTrailStyle dictionary</a> <a href="#ref-for-idl-unrestricted-double①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
    <a href="https://heycam.github.io/webidl/#idl-unsigned-long">https://heycam.github.io/webidl/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-unsigned-long">3.3. InkPresenter interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
+    <li><a href="#ref-for-idl-unsigned-long">3.4. InkPresenter interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -943,7 +935,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-pointerevents3">[POINTEREVENTS3]
-   <dd>Patrick Lauke; et al. <a href="https://www.w3.org/TR/pointerevents3/">Pointer Events</a>. 7 July 2021. WD. URL: <a href="https://www.w3.org/TR/pointerevents3/">https://www.w3.org/TR/pointerevents3/</a>
+   <dd>Patrick Lauke; et al. <a href="https://www.w3.org/TR/pointerevents3/">Pointer Events</a>. 8 July 2021. WD. URL: <a href="https://www.w3.org/TR/pointerevents3/">https://www.w3.org/TR/pointerevents3/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-webidl">[WebIDL]
@@ -952,8 +944,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>interface</c-> <a href="#ink"><code><c- g>Ink</c-></code></a> {
     <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#inkpresenter"><c- n>InkPresenter</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-ink-requestpresenter"><c- g>requestPresenter</c-></a>(
-        <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-ink-requestpresenter-type-presentationarea-type"><code><c- g>type</c-></code></a>,
-        <c- b>optional</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element"><c- n>Element</c-></a>? <a href="#dom-ink-requestpresenter-type-presentationarea-presentationarea"><code><c- g>presentationArea</c-></code></a> = <c- b>null</c->);
+        <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-inkpresenterparam"><c- n>InkPresenterParam</c-></a>? <a href="#dom-ink-requestpresenter-param-param"><code><c- g>param</c-></code></a> = <c- b>null</c->);
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-inkpresenterparam"><code><c- g>InkPresenterParam</c-></code></a> {
+    <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element"><c- n>Element</c-></a>? <a class="idl-code" data-default="null" data-link-type="dict-member" data-type="Element? " href="#dom-inkpresenterparam-presentationarea"><c- g>presentationArea</c-></a> = <c- b>null</c->;
 };
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
@@ -979,19 +974,27 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <b><a href="#ink">#ink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink">3.2. Ink interface</a>
-    <li><a href="#ref-for-ink①">3.5. Ink Navigator interface extension</a> <a href="#ref-for-ink②">(2)</a> <a href="#ref-for-ink③">(3)</a> <a href="#ref-for-ink④">(4)</a>
+    <li><a href="#ref-for-ink①">3.6. Ink Navigator interface extension</a> <a href="#ref-for-ink②">(2)</a> <a href="#ref-for-ink③">(3)</a> <a href="#ref-for-ink④">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-ink-requestpresenter">
    <b><a href="#dom-ink-requestpresenter">#dom-ink-requestpresenter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-ink-requestpresenter">3.2. Ink interface</a> <a href="#ref-for-dom-ink-requestpresenter①">(2)</a>
+    <li><a href="#ref-for-dom-ink-requestpresenter">3.2. Ink interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-ink-requestpresenter-presentationarea">
-   <b><a href="#dom-ink-requestpresenter-presentationarea">#dom-ink-requestpresenter-presentationarea</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dictdef-inkpresenterparam">
+   <b><a href="#dictdef-inkpresenterparam">#dictdef-inkpresenterparam</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-ink-requestpresenter-presentationarea">3.5. Ink Navigator interface extension</a>
+    <li><a href="#ref-for-dictdef-inkpresenterparam">3.2. Ink interface</a>
+    <li><a href="#ref-for-dictdef-inkpresenterparam①">3.3. InkPresenterParam dictionary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-inkpresenterparam-presentationarea">
+   <b><a href="#dom-inkpresenterparam-presentationarea">#dom-inkpresenterparam-presentationarea</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-inkpresenterparam-presentationarea">3.3. InkPresenterParam dictionary</a>
+    <li><a href="#ref-for-dom-inkpresenterparam-presentationarea①">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="inkpresenter">
@@ -999,50 +1002,50 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <ul>
     <li><a href="#ref-for-inkpresenter">3.1. Introduction</a>
     <li><a href="#ref-for-inkpresenter①">3.2. Ink interface</a>
-    <li><a href="#ref-for-inkpresenter②">3.3. InkPresenter interface</a> <a href="#ref-for-inkpresenter③">(2)</a>
+    <li><a href="#ref-for-inkpresenter②">3.4. InkPresenter interface</a> <a href="#ref-for-inkpresenter③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-inkpresenter-presentationarea">
    <b><a href="#dom-inkpresenter-presentationarea">#dom-inkpresenter-presentationarea</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-inkpresenter-presentationarea">3.3. InkPresenter interface</a>
+    <li><a href="#ref-for-dom-inkpresenter-presentationarea">3.4. InkPresenter interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-inkpresenter-expectedimprovement">
    <b><a href="#dom-inkpresenter-expectedimprovement">#dom-inkpresenter-expectedimprovement</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-inkpresenter-expectedimprovement">3.3. InkPresenter interface</a>
+    <li><a href="#ref-for-dom-inkpresenter-expectedimprovement">3.4. InkPresenter interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-inkpresenter-updateinktrailstartpoint">
    <b><a href="#dom-inkpresenter-updateinktrailstartpoint">#dom-inkpresenter-updateinktrailstartpoint</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-inkpresenter-updateinktrailstartpoint">3.3. InkPresenter interface</a>
+    <li><a href="#ref-for-dom-inkpresenter-updateinktrailstartpoint">3.4. InkPresenter interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-inktrailstyle">
    <b><a href="#dictdef-inktrailstyle">#dictdef-inktrailstyle</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-inktrailstyle">3.3. InkPresenter interface</a>
-    <li><a href="#ref-for-dictdef-inktrailstyle①">3.4. InkTrailStyle dictionary</a>
+    <li><a href="#ref-for-dictdef-inktrailstyle">3.4. InkPresenter interface</a>
+    <li><a href="#ref-for-dictdef-inktrailstyle①">3.5. InkTrailStyle dictionary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-inktrailstyle-color">
    <b><a href="#dom-inktrailstyle-color">#dom-inktrailstyle-color</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-inktrailstyle-color">3.4. InkTrailStyle dictionary</a>
+    <li><a href="#ref-for-dom-inktrailstyle-color">3.5. InkTrailStyle dictionary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-inktrailstyle-diameter">
    <b><a href="#dom-inktrailstyle-diameter">#dom-inktrailstyle-diameter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-inktrailstyle-diameter">3.4. InkTrailStyle dictionary</a>
+    <li><a href="#ref-for-dom-inktrailstyle-diameter">3.5. InkTrailStyle dictionary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-navigator-ink">
    <b><a href="#dom-navigator-ink">#dom-navigator-ink</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-navigator-ink">3.5. Ink Navigator interface extension</a>
+    <li><a href="#ref-for-dom-navigator-ink">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
#20 
This PR updates `requestPresenter()` to drop the `type` and `presentationArea` parameters in favor of a dictionary. This optional dictionary parameter, called `InkPresenterParam`, will currently only contain an optional `presentationArea` element. Because the string is currently a no-op, it was decided that it is best to leave it off. If `requestPresenter` needs to be extended in the future, then a new `type` param can be added to this dictionary to allow it to be extended.

#28 
This PR also adds a line about the delegated ink trail only being rendered for a single frame before being removed.