### PR TITLE
Replace InkPresenter with DelegatedInkTrailPresenter

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,7 +609,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li><a href="#ink-api-introduction"><span class="secno">3.1</span> <span class="content">Introduction</span></a>
       <li><a href="#ink-interface"><span class="secno">3.2</span> <span class="content"><code class="idl"><span>Ink</span></code> interface</span></a>
       <li><a href="#ink-presenter-param"><span class="secno">3.3</span> <span class="content"><code class="idl"><span>InkPresenterParam</span></code> dictionary</span></a>
-      <li><a href="#ink-presenter"><span class="secno">3.4</span> <span class="content"><code class="idl"><span>InkPresenter</span></code> interface</span></a>
+      <li><a href="#ink-presenter"><span class="secno">3.4</span> <span class="content"><code class="idl"><span>DelegatedInkTrailPresenter</span></code> interface</span></a>
       <li><a href="#ink-trail-style"><span class="secno">3.5</span> <span class="content"><code class="idl"><span>InkTrailStyle</span></code> dictionary</span></a>
       <li><a href="#navigator-interface-extensions"><span class="secno">3.6</span> <span class="content"><code class="idl"><span>Ink</span></code> Navigator interface extension</span></a>
      </ol>
@@ -648,17 +648,17 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <p><img src="enhanced-ink-flow-2.png" width="700"></p>
    <p>When the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent①">PointerEvent</a></code> is delivered to the web application, the application can seamlessly replace the system compositor ink with application rendered strokes and update the compositor on the last event point that it rendered:</p>
    <p><img src="enhanced-ink-flow-3.png" width="700"></p>
-   <p>The Ink API provides the <code class="idl"><a data-link-type="idl" href="#inkpresenter" id="ref-for-inkpresenter">InkPresenter</a></code> interface to expose the underlying operating system API to achieve this and keeps the extensibility open in order to support additonal presenters in the future.</p>
+   <p>The Ink API provides the <code class="idl"><a data-link-type="idl" href="#delegatedinktrailpresenter" id="ref-for-delegatedinktrailpresenter">DelegatedInkTrailPresenter</a></code> interface to expose the underlying operating system API to achieve this and keeps the extensibility open in order to support additonal presenters in the future.</p>
    <h3 class="heading settled" data-level="3.2" id="ink-interface"><span class="secno">3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#ink" id="ref-for-ink">Ink</a></code> interface</span><a class="self-link" href="#ink-interface"></a></h3>
 <pre class="idl lang-idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="ink"><code><c- g>Ink</c-></code></dfn> {
-    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#inkpresenter" id="ref-for-inkpresenter①"><c- n>InkPresenter</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-ink-requestpresenter" id="ref-for-dom-ink-requestpresenter"><c- g>requestPresenter</c-></a>(
+    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#delegatedinktrailpresenter" id="ref-for-delegatedinktrailpresenter①"><c- n>DelegatedInkTrailPresenter</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-ink-requestpresenter" id="ref-for-dom-ink-requestpresenter"><c- g>requestPresenter</c-></a>(
         <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-inkpresenterparam" id="ref-for-dictdef-inkpresenterparam"><c- n>InkPresenterParam</c-></a>? <dfn class="idl-code" data-dfn-for="Ink/requestPresenter(param), Ink/requestPresenter()" data-dfn-type="argument" data-export id="dom-ink-requestpresenter-param-param"><code><c- g>param</c-></code><a class="self-link" href="#dom-ink-requestpresenter-param-param"></a></dfn> = <c- b>null</c->);
 };
 </pre>
    <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="Ink" data-dfn-type="method" data-export data-lt="requestPresenter(param)|requestPresenter()" id="dom-ink-requestpresenter"><code>requestPresenter(param)</code></dfn>
     <dd data-md>
-     <p>This method returns an instance of an InkPresenter object within a Promise that can be used to render ink strokes in-between <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent②">PointerEvent</a></code> dispatches. Each time this method is called, a new InkPresenter instance must be created.</p>
+     <p>This method returns an instance of an DelegatedInkTrailPresenter object within a Promise that can be used to render ink strokes in-between <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent②">PointerEvent</a></code> dispatches. Each time this method is called, a new DelegatedInkTrailPresenter instance must be created.</p>
    </dl>
    <h3 class="heading settled" data-level="3.3" id="ink-presenter-param"><span class="secno">3.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dictdef-inkpresenterparam" id="ref-for-dictdef-inkpresenterparam①">InkPresenterParam</a></code> dictionary</span><a class="self-link" href="#ink-presenter-param"></a></h3>
 <pre class="idl lang-idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-inkpresenterparam"><code><c- g>InkPresenterParam</c-></code></dfn> {
@@ -670,23 +670,23 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <dd data-md>
      <p>An optional <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> that confines the rendering of ink trails to the area bound by the element. presentationArea must either be null or be in the same document as the Ink interface, otherwise throw an error and abort.</p>
    </dl>
-   <h3 class="heading settled" data-level="3.4" id="ink-presenter"><span class="secno">3.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#inkpresenter" id="ref-for-inkpresenter②">InkPresenter</a></code> interface</span><a class="self-link" href="#ink-presenter"></a></h3>
+   <h3 class="heading settled" data-level="3.4" id="ink-presenter"><span class="secno">3.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#delegatedinktrailpresenter" id="ref-for-delegatedinktrailpresenter②">DelegatedInkTrailPresenter</a></code> interface</span><a class="self-link" href="#ink-presenter"></a></h3>
 <pre class="idl lang-idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
-<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="inkpresenter"><code><c- g>InkPresenter</c-></code></dfn> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③"><c- n>Element</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="Element?" href="#dom-inkpresenter-presentationarea" id="ref-for-dom-inkpresenter-presentationarea"><c- g>presentationArea</c-></a>;
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="delegatedinktrailpresenter"><code><c- g>DelegatedInkTrailPresenter</c-></code></dfn> {
+    <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③"><c- n>Element</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="Element?" href="#dom-delegatedinktrailpresenter-presentationarea" id="ref-for-dom-delegatedinktrailpresenter-presentationarea"><c- g>presentationArea</c-></a>;
 
-    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-inkpresenter-updateinktrailstartpoint" id="ref-for-dom-inkpresenter-updateinktrailstartpoint"><c- g>updateInkTrailStartPoint</c-></a>(<a data-link-type="idl-name" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent③"><c- n>PointerEvent</c-></a> <dfn class="idl-code" data-dfn-for="InkPresenter/updateInkTrailStartPoint(event, style)" data-dfn-type="argument" data-export id="dom-inkpresenter-updateinktrailstartpoint-event-style-event"><code><c- g>event</c-></code><a class="self-link" href="#dom-inkpresenter-updateinktrailstartpoint-event-style-event"></a></dfn>, <a data-link-type="idl-name" href="#dictdef-inktrailstyle" id="ref-for-dictdef-inktrailstyle"><c- n>InkTrailStyle</c-></a> <dfn class="idl-code" data-dfn-for="InkPresenter/updateInkTrailStartPoint(event, style)" data-dfn-type="argument" data-export id="dom-inkpresenter-updateinktrailstartpoint-event-style-style"><code><c- g>style</c-></code><a class="self-link" href="#dom-inkpresenter-updateinktrailstartpoint-event-style-style"></a></dfn>);
+    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-delegatedinktrailpresenter-updateinktrailstartpoint" id="ref-for-dom-delegatedinktrailpresenter-updateinktrailstartpoint"><c- g>updateInkTrailStartPoint</c-></a>(<a data-link-type="idl-name" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent③"><c- n>PointerEvent</c-></a> <dfn class="idl-code" data-dfn-for="DelegatedInkTrailPresenter/updateInkTrailStartPoint(event, style)" data-dfn-type="argument" data-export id="dom-delegatedinktrailpresenter-updateinktrailstartpoint-event-style-event"><code><c- g>event</c-></code><a class="self-link" href="#dom-delegatedinktrailpresenter-updateinktrailstartpoint-event-style-event"></a></dfn>, <a data-link-type="idl-name" href="#dictdef-inktrailstyle" id="ref-for-dictdef-inktrailstyle"><c- n>InkTrailStyle</c-></a> <dfn class="idl-code" data-dfn-for="DelegatedInkTrailPresenter/updateInkTrailStartPoint(event, style)" data-dfn-type="argument" data-export id="dom-delegatedinktrailpresenter-updateinktrailstartpoint-event-style-style"><code><c- g>style</c-></code><a class="self-link" href="#dom-delegatedinktrailpresenter-updateinktrailstartpoint-event-style-style"></a></dfn>);
 };
 </pre>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkPresenter" data-dfn-type="attribute" data-export id="dom-inkpresenter-presentationarea"><code>presentationArea</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a>, readonly, nullable</span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="DelegatedInkTrailPresenter" data-dfn-type="attribute" data-export id="dom-delegatedinktrailpresenter-presentationarea"><code>presentationArea</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a>, readonly, nullable</span>
     <dd data-md>
-     <p>A reference to the DOM element to which the presenter is scoped to prevent ink presentation outside of the provided area. This area is always the client coordinates for the element’s border box, so moving the element or scrolling the element requires no recalculation on the author’s part. If this is not provided, the default is to use the containing viewport. This element must be in the same document that the InkPresenter is associated with and the same document that is receiving the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent④">PointerEvent</a></code>s, otherwise an error is thrown. If presentationArea is ever removed from the document, the next updateInkTrailStartPoint must throw an error and abort.</p>
+     <p>A reference to the DOM element to which the presenter is scoped to prevent ink presentation outside of the provided area. This area is always the client coordinates for the element’s border box, so moving the element or scrolling the element requires no recalculation on the author’s part. If this is not provided, the default is to use the containing viewport. This element must be in the same document that the DelegatedInkTrailPresenter is associated with and the same document that is receiving the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent④">PointerEvent</a></code>s, otherwise an error is thrown. If presentationArea is ever removed from the document, the next updateInkTrailStartPoint must throw an error and abort.</p>
    </dl>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="InkPresenter" data-dfn-type="method" data-export id="dom-inkpresenter-updateinktrailstartpoint"><code>updateInkTrailStartPoint(event, style)</code></dfn>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="DelegatedInkTrailPresenter" data-dfn-type="method" data-export id="dom-delegatedinktrailpresenter-updateinktrailstartpoint"><code>updateInkTrailStartPoint(event, style)</code></dfn>
     <dd data-md>
-     <p>This method indicates to the presenter which <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent⑤">PointerEvent</a></code> was used as the last rendering point for the current frame. This must be a trusted event that is in the same document as the <code class="idl"><a data-link-type="idl" href="#inkpresenter" id="ref-for-inkpresenter③">InkPresenter</a></code>. The produced delegated ink trail must be rendered for the duration of the next animation frame and then removed.</p>
+     <p>This method indicates to the presenter which <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent" id="ref-for-dom-pointerevent⑤">PointerEvent</a></code> was used as the last rendering point for the current frame. This must be a trusted event that is in the same document as the <code class="idl"><a data-link-type="idl" href="#delegatedinktrailpresenter" id="ref-for-delegatedinktrailpresenter③">DelegatedInkTrailPresenter</a></code>. The produced delegated ink trail must be rendered for the duration of the next animation frame and then removed.</p>
    </dl>
    <h3 class="heading settled" data-level="3.5" id="ink-trail-style"><span class="secno">3.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dictdef-inktrailstyle" id="ref-for-dictdef-inktrailstyle①">InkTrailStyle</a></code> dictionary</span><a class="self-link" href="#ink-trail-style"></a></h3>
 <pre class="idl lang-idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-inktrailstyle"><code><c- g>InkTrailStyle</c-></code></dfn> {
@@ -793,24 +793,24 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#dom-inktrailstyle-diameter">diameter</a><span>, in §3.5</span>
    <li><a href="#ink">Ink</a><span>, in §3.2</span>
    <li><a href="#dom-navigator-ink">ink</a><span>, in §3.6</span>
-   <li><a href="#inkpresenter">InkPresenter</a><span>, in §3.4</span>
+   <li><a href="#delegatedinktrailpresenter">DelegatedInkTrailPresenter</a><span>, in §3.4</span>
    <li><a href="#dictdef-inkpresenterparam">InkPresenterParam</a><span>, in §3.3</span>
    <li><a href="#dictdef-inktrailstyle">InkTrailStyle</a><span>, in §3.5</span>
    <li>
     presentationArea
     <ul>
-     <li><a href="#dom-inkpresenter-presentationarea">attribute for InkPresenter</a><span>, in §3.4</span>
+     <li><a href="#dom-delegatedinktrailpresenter-presentationarea">attribute for DelegatedInkTrailPresenter</a><span>, in §3.4</span>
      <li><a href="#dom-inkpresenterparam-presentationarea">dict-member for InkPresenterParam</a><span>, in §3.3</span>
     </ul>
    <li><a href="#dom-ink-requestpresenter">requestPresenter()</a><span>, in §3.2</span>
    <li><a href="#dom-ink-requestpresenter">requestPresenter(param)</a><span>, in §3.2</span>
-   <li><a href="#dom-inkpresenter-updateinktrailstartpoint">updateInkTrailStartPoint(event, style)</a><span>, in §3.4</span>
+   <li><a href="#dom-delegatedinktrailpresenter-updateinktrailstartpoint">updateInkTrailStartPoint(event, style)</a><span>, in §3.4</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-element">
    <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">3.3. InkPresenterParam dictionary</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a>
-    <li><a href="#ref-for-element③">3.4. InkPresenter interface</a> <a href="#ref-for-element④">(2)</a>
+    <li><a href="#ref-for-element③">3.4. DelegatedInkTrailPresenter interface</a> <a href="#ref-for-element④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-navigator">
@@ -831,7 +831,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-dom-pointerevent">1. Introduction</a>
     <li><a href="#ref-for-dom-pointerevent①">3.1. Introduction</a>
     <li><a href="#ref-for-dom-pointerevent②">3.2. Ink interface</a>
-    <li><a href="#ref-for-dom-pointerevent③">3.4. InkPresenter interface</a> <a href="#ref-for-dom-pointerevent④">(2)</a> <a href="#ref-for-dom-pointerevent⑤">(3)</a>
+    <li><a href="#ref-for-dom-pointerevent③">3.4. DelegatedInkTrailPresenter interface</a> <a href="#ref-for-dom-pointerevent④">(2)</a> <a href="#ref-for-dom-pointerevent⑤">(3)</a>
     <li><a href="#ref-for-dom-pointerevent⑥">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
@@ -850,7 +850,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="term-for-Exposed">
    <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Exposed">3.4. InkPresenter interface</a>
+    <li><a href="#ref-for-Exposed">3.4. DelegatedInkTrailPresenter interface</a>
     <li><a href="#ref-for-Exposed①">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
@@ -869,7 +869,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="term-for-idl-undefined">
    <a href="https://heycam.github.io/webidl/#idl-undefined">https://heycam.github.io/webidl/#idl-undefined</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-undefined">3.4. InkPresenter interface</a>
+    <li><a href="#ref-for-idl-undefined">3.4. DelegatedInkTrailPresenter interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
@@ -881,7 +881,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
    <a href="https://heycam.github.io/webidl/#idl-unsigned-long">https://heycam.github.io/webidl/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-unsigned-long">3.4. InkPresenter interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
+    <li><a href="#ref-for-idl-unsigned-long">3.4. DelegatedInkTrailPresenter interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -931,7 +931,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>interface</c-> <a href="#ink"><code><c- g>Ink</c-></code></a> {
-    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#inkpresenter"><c- n>InkPresenter</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-ink-requestpresenter"><c- g>requestPresenter</c-></a>(
+    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#delegatedinktrailpresenter"><c- n>DelegatedInkTrailPresenter</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-ink-requestpresenter"><c- g>requestPresenter</c-></a>(
         <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-inkpresenterparam"><c- n>InkPresenterParam</c-></a>? <a href="#dom-ink-requestpresenter-param-param"><code><c- g>param</c-></code></a> = <c- b>null</c->);
 };
 
@@ -940,10 +940,10 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 };
 
 [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
-<c- b>interface</c-> <a href="#inkpresenter"><code><c- g>InkPresenter</c-></code></a> {
-    <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element"><c- n>Element</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="Element?" href="#dom-inkpresenter-presentationarea"><c- g>presentationArea</c-></a>;
+<c- b>interface</c-> <a href="#delegatedinktrailpresenter"><code><c- g>DelegatedInkTrailPresenter</c-></code></a> {
+    <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element"><c- n>Element</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="Element?" href="#dom-delegatedinktrailpresenter-presentationarea"><c- g>presentationArea</c-></a>;
 
-    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-inkpresenter-updateinktrailstartpoint"><c- g>updateInkTrailStartPoint</c-></a>(<a data-link-type="idl-name" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent"><c- n>PointerEvent</c-></a> <a href="#dom-inkpresenter-updateinktrailstartpoint-event-style-event"><code><c- g>event</c-></code></a>, <a data-link-type="idl-name" href="#dictdef-inktrailstyle"><c- n>InkTrailStyle</c-></a> <a href="#dom-inkpresenter-updateinktrailstartpoint-event-style-style"><code><c- g>style</c-></code></a>);
+    <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-delegatedinktrailpresenter-updateinktrailstartpoint"><c- g>updateInkTrailStartPoint</c-></a>(<a data-link-type="idl-name" href="https://www.w3.org/TR/pointerevents3/#dom-pointerevent"><c- n>PointerEvent</c-></a> <a href="#dom-delegatedinktrailpresenter-updateinktrailstartpoint-event-style-event"><code><c- g>event</c-></code></a>, <a data-link-type="idl-name" href="#dictdef-inktrailstyle"><c- n>InkTrailStyle</c-></a> <a href="#dom-delegatedinktrailpresenter-updateinktrailstartpoint-event-style-style"><code><c- g>style</c-></code></a>);
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-inktrailstyle"><code><c- g>InkTrailStyle</c-></code></a> {
@@ -984,30 +984,30 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-dom-inkpresenterparam-presentationarea①">3.6. Ink Navigator interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inkpresenter">
-   <b><a href="#inkpresenter">#inkpresenter</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="delegatedinktrailpresenter">
+   <b><a href="#delegatedinktrailpresenter">#delegatedinktrailpresenter</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-inkpresenter">3.1. Introduction</a>
-    <li><a href="#ref-for-inkpresenter①">3.2. Ink interface</a>
-    <li><a href="#ref-for-inkpresenter②">3.4. InkPresenter interface</a> <a href="#ref-for-inkpresenter③">(2)</a>
+    <li><a href="#ref-for-delegatedinktrailpresenter">3.1. Introduction</a>
+    <li><a href="#ref-for-delegatedinktrailpresenter①">3.2. Ink interface</a>
+    <li><a href="#ref-for-delegatedinktrailpresenter②">3.4. DelegatedInkTrailPresenter interface</a> <a href="#ref-for-delegatedinktrailpresenter③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-inkpresenter-presentationarea">
-   <b><a href="#dom-inkpresenter-presentationarea">#dom-inkpresenter-presentationarea</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-delegatedinktrailpresenter-presentationarea">
+   <b><a href="#dom-delegatedinktrailpresenter-presentationarea">#dom-delegatedinktrailpresenter-presentationarea</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-inkpresenter-presentationarea">3.4. InkPresenter interface</a>
+    <li><a href="#ref-for-dom-delegatedinktrailpresenter-presentationarea">3.4. DelegatedInkTrailPresenter interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-inkpresenter-updateinktrailstartpoint">
-   <b><a href="#dom-inkpresenter-updateinktrailstartpoint">#dom-inkpresenter-updateinktrailstartpoint</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-delegatedinktrailpresenter-updateinktrailstartpoint">
+   <b><a href="#dom-delegatedinktrailpresenter-updateinktrailstartpoint">#dom-delegatedinktrailpresenter-updateinktrailstartpoint</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-inkpresenter-updateinktrailstartpoint">3.4. InkPresenter interface</a>
+    <li><a href="#ref-for-dom-delegatedinktrailpresenter-updateinktrailstartpoint">3.4. DelegatedInkTrailPresenter interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-inktrailstyle">
    <b><a href="#dictdef-inktrailstyle">#dictdef-inktrailstyle</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-inktrailstyle">3.4. InkPresenter interface</a>
+    <li><a href="#ref-for-dictdef-inktrailstyle">3.4. DelegatedInkTrailPresenter interface</a>
     <li><a href="#ref-for-dictdef-inktrailstyle①">3.5. InkTrailStyle dictionary</a>
    </ul>
   </aside>


### PR DESCRIPTION
This PR addresses #35. There is no current plan to have multiple ink presenters. If there is a need for future ink presenters, the specification can be updated easily to accomodate the change. Additional context for this change is available in the TAG review: https://github.com/w3ctag/design-reviews/issues/473